### PR TITLE
add option to prevent a buffer overflow crash

### DIFF
--- a/history.markdown
+++ b/history.markdown
@@ -3,7 +3,7 @@
 
  * asBuffer option to support native switches between strings and buffers
  * update send/recv functions for better buffer handling
- * force buffer lengths to be exact measurments passed to nn_send/nn_recv
+ * force buffer lengths to be exact measurements passed to nn_send/nn_recv
  * ensure data sent as C strings are null/zero terminated
  * port a kernel multiplexer function to javascript (lib/getevent.h)
  * test multiple heterogeneous endpoints and add other cool tests

--- a/index.js
+++ b/index.js
@@ -86,9 +86,18 @@ function self (s, t, o) {
     case 'rep':
     case 'pull':
       if(this.asBuffer){
-        this.clr = setInterval(select, 0)
+        //check for a buffer overflow option before i/o multiplexing
+        if(o.hasOwnProperty('stopBufferOverflow')){
+          this.clr = setInterval(select_buf, 0)
+        } else {
+          this.clr = setInterval(select, 0)
+        }
       } else {
-        this.clr = setInterval(select_s, 0)
+        if(o.hasOwnProperty('stopBufferOverflow')){
+          this.clr = setInterval(select_s_buf, 0)
+        } else {
+          this.clr = setInterval(select_s, 0)
+        }
       }
       break;
   }
@@ -99,6 +108,14 @@ function self (s, t, o) {
 
   function select_s(){
     while(nn.Multiplexer(ctx.socket) > 0) ctx.recv(nn.RecvStr(ctx.socket))
+  }
+
+  function select_buf(){
+    if(nn.Multiplexer(ctx.socket) > 0) ctx.recv(nn.Recv(ctx.socket))
+  }
+
+  function select_s_buf(){
+    if(nn.Multiplexer(ctx.socket) > 0) ctx.recv(nn.RecvStr(ctx.socket))
   }
 }
 

--- a/test/nanomsg.sendperf.js
+++ b/test/nanomsg.sendperf.js
@@ -6,7 +6,8 @@ describe('nanomsg.sendperf', function() {
 
   var pub    = nano.socket('pub')
   var sub    = nano.socket('sub',{
-    asBuffer:true
+    asBuffer:true,
+    stopBufferOverflow: true
   })
   var recv    = 0
   var addr    = 'inproc://whatever'

--- a/test/nanomsg.stream.js
+++ b/test/nanomsg.stream.js
@@ -8,7 +8,10 @@ describe('nanomsg.stream', function() {
   it('should stream a hundred inbound messages', function(done){
 
     var pub    = nano.socket('pub'), recv = 0
-    var sub    = nano.socket('sub',{ stream: true })
+    var sub    = nano.socket('sub',{
+      stream: true,
+      stopBufferOverflow:true
+    })
     sub.connect('inproc://stream')
     pub.bind('inproc://stream')
 


### PR DESCRIPTION
on some types of linux systems i discovered an edge case where a buffer
overflow would occur during the i/o multiplexing calls. this would
immediately crash the process with something like an Abort Trap or
Segmentation Fault (segfault) type of system call.

If we limit the specific call to the multiplexer function to only occur
once per NodeJS eventloop tick, it appears that we can prevent this
crash.

Note: this option will reduce performance where we are sending multiple
messages per millisecond or multiple messages per tick of the
NodeJS/IOJS eventloop
