### PR TITLE
last of the perf fixes after porting from zmq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ clean:
 	rm -rf node_modules
 
 perf:
-	#node perf/local_lat.js tcp://127.0.0.1:5555 1 100000& node perf/remote_lat.js tcp://127.0.0.1:5555 1 100000
-	node perf/local_thr.js tcp://127.0.0.1:5556 1 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 1 100000
+	node perf/local_lat.js tcp://127.0.0.1:5555 10 1000& node perf/remote_lat.js tcp://127.0.0.1:5555 10 1000
+	node perf/local_thr.js tcp://127.0.0.1:5556 10 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 10 100000

--- a/perf/local_lat.js
+++ b/perf/local_lat.js
@@ -20,6 +20,7 @@ rep.on('msg', function (data) {
   if (++counter === roundtrip_count){
     setTimeout( function(){
       rep.close();
+      process.exit(0);
     }, 1000);
   }
 })

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -2,7 +2,7 @@ var nano = require('../');
 var assert = require('assert');
 
 if (process.argv.length != 5) {
-  console.log('usage: local_thr <bind-to> <msg-size> <msg-count>');
+  console.log('usage: local_thr <bind-to> <message-size> <message-count>');
   process.exit(1);
 }
 
@@ -11,9 +11,7 @@ var message_size = Number(process.argv[3]);
 var message_count = Number(process.argv[4]);
 var counter = 0;
 
-var sock = nano.socket('pull',{
-  //stopBufferOverflow:true
-});
+var sock = nano.socket('pull');
 sock.bind(bind_to);
 
 var timer;
@@ -24,7 +22,7 @@ sock.on('msg', function (data) {
     timer = process.hrtime();
   }
 
-  assert.equal(data.length, message_size, 'msg-size did not match');
+  assert.equal(data.length, message_size, 'message-size did not match');
   if (++counter === message_count) finish();
 })
 
@@ -34,8 +32,8 @@ function finish(){
   var throughput = message_count / sec;
   var megabits = (throughput * message_size * 8) / 1000000;
 
-  console.log('msg size: %d [B]', message_size);
-  console.log('msg count: %d', message_count);
+  console.log('message size: %d [B]', message_size);
+  console.log('message count: %d', message_count);
   console.log('mean throughput: %d [msg/s]', throughput.toFixed(0));
   console.log('mean throughput: %d [Mbit/s]', megabits.toFixed(0));
   console.log('overall time: %d secs and %d nanoseconds', endtime[0], endtime[1]);

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -39,5 +39,5 @@ function finish(){
   console.log('mean throughput: %d [msg/s]', throughput.toFixed(0));
   console.log('mean throughput: %d [Mbit/s]', megabits.toFixed(0));
   console.log('overall time: %d secs and %d nanoseconds', endtime[0], endtime[1]);
-  //sock.close();
+  process.exit(1);
 }

--- a/perf/remote_lat.js
+++ b/perf/remote_lat.js
@@ -42,7 +42,7 @@ function finish() {
   console.log('roundtrip count: %d', roundtrip_count);
   console.log('mean latency: %d [msecs]', millis / (roundtrip_count * 2));
   console.log('overall time: %d secs and %d nanoseconds', duration[0], duration[1]);
-  req.close()
+  process.exit(0)
 }
 
 function send() {

--- a/perf/remote_thr.js
+++ b/perf/remote_thr.js
@@ -2,15 +2,15 @@ var nano = require('../')
 var assert = require('assert')
 
 if (process.argv.length != 5) {
-  console.log('usage: remote_thr <bind-to> <msg-size> <msg-count>')
+  console.log('usage: remote_thr <bind-to> <message-size> <message-count>')
   process.exit(1)
 }
 
 var connect_to = process.argv[2]
 var message_size = Number(process.argv[3])
 var message_count = Number(process.argv[4])
-var msg = new Buffer(message_size)
-msg.fill('h')
+var message = new Buffer(message_size)
+message.fill('h')
 
 var counter = 0
 
@@ -19,7 +19,7 @@ sock.connect(connect_to)
 
 function send(){
   for (var i = 0; i < message_count; i++) {
-    sock.send(msg)
+    sock.send(message)
   }
 
   // all messages may not be received by local_thr if closed immediately


### PR DESCRIPTION
when i was running `make perf` it would keep some of living node processes backgrounded after completion. 

here's a stiffer drink with `process.exit()` instead of `socket.close()`
