### PR TITLE
EventEmitter mechanism replaced by Streams

### DIFF
--- a/perf/local_lat.js
+++ b/perf/local_lat.js
@@ -14,9 +14,9 @@ var counter = 0;
 var rep = nano.socket('rep');
 rep.bind(bind_to);
 
-rep.on('msg', function (data) {
+rep.on('data', function (data) {
   assert.equal(data.length, message_size, 'message-size did not match');
-  rep.send(data);
+  rep.write(data);
   if (++counter === roundtrip_count){
     setTimeout( function(){
       rep.close();

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -16,7 +16,7 @@ sock.bind(bind_to);
 
 var timer;
 
-sock.on('msg', function (data) {
+sock.on('data', function (data) {
   if (!timer) {
     console.log('started receiving');
     timer = process.hrtime();

--- a/perf/remote_lat.js
+++ b/perf/remote_lat.js
@@ -19,7 +19,7 @@ req.connect(connect_to);
 
 var timer;
 
-req.on('msg', function (data) {
+req.on('data', function (data) {
   if (!timer) {
     console.log('started receiving');
     timer = process.hrtime();
@@ -46,7 +46,7 @@ function finish() {
 }
 
 function send() {
-  req.send(message);
+  req.write(message);
 }
 
 send()

--- a/perf/remote_thr.js
+++ b/perf/remote_thr.js
@@ -19,7 +19,7 @@ sock.connect(connect_to)
 
 function send(){
   for (var i = 0; i < message_count; i++) {
-    sock.send(message)
+    sock.write(message)
   }
 
   // all messages may not be received by local_thr if closed immediately

--- a/test/nanomsg.bindtransports.js
+++ b/test/nanomsg.bindtransports.js
@@ -7,23 +7,23 @@ describe('nanomsg.transports', function() {
   it('should bind, connect, send and receive over tcp', function(done){
     var addr  = 'tcp://127.0.0.1:44442'
     var req = nano.socket('req')
-    var rep = nano.socket('rep',{asBuffer:false})
+    var rep = nano.socket('rep')
 
     rep.connect(addr)
     req.bind(addr)
 
-    req.on('msg',function(msg){
+    req.on('data', function(msg){
       msg.should.be.an.instanceOf(Buffer)
       String(msg).should.equal('foo ack bar')
       done()
     })
 
-    rep.on('msg',function(msg){
-      msg.should.equal('sent over tcp')
-      rep.send('foo ack bar')
+    rep.on('data',function(msg){
+      String(msg).should.equal('sent over tcp')
+      rep.write('foo ack bar')
     })
 
-    req.send('sent over tcp')
+    req.write('sent over tcp')
 
   })
 
@@ -31,23 +31,24 @@ describe('nanomsg.transports', function() {
 
     var addr  = 'inproc://foo'
     var req = nano.socket('req')
-    var rep = nano.socket('rep',{asBuffer:false})
+    var rep = nano.socket('rep')
 
     rep.connect(addr)
     req.bind(addr)
 
-    req.on('msg',function(msg){
+    req.on('data',function(msg){
       msg.should.be.an.instanceOf(Buffer)
       String(msg).should.equal('foo ack bar')
       done()
     })
 
-    rep.on('msg',function(msg){
-      msg.should.equal('sent over inproc')
+    rep.on('data',function(msg){
+      msg.should.be.an.instanceOf(Buffer)
+      String(msg).should.equal('sent over inproc')
       rep.send('foo ack bar')
     })
 
-    req.send('sent over inproc')
+    req.write('sent over inproc')
 
   })
 
@@ -55,12 +56,12 @@ describe('nanomsg.transports', function() {
 
     var addr  = 'ipc://bar'
     var req = nano.socket('req')
-    var rep = nano.socket('rep',{asBuffer:false})
+    var rep = nano.socket('rep')
 
     rep.connect(addr)
     req.bind(addr)
 
-    req.on('msg',function(msg){
+    req.on('data',function(msg){
       msg.should.be.an.instanceOf(Buffer)
       String(msg).should.equal('foo ack bar')
 
@@ -71,12 +72,13 @@ describe('nanomsg.transports', function() {
       })
     })
 
-    rep.on('msg',function(msg){
-      msg.should.equal('sent over ipc')
+    rep.on('data',function(msg){
+      msg.should.be.an.instanceOf(Buffer)
+      String(msg).should.equal('sent over ipc')
       rep.send('foo ack bar')
     })
 
-    req.send('sent over ipc')
+    req.write('sent over ipc')
 
   })
 

--- a/test/nanomsg.buffer.js
+++ b/test/nanomsg.buffer.js
@@ -3,23 +3,18 @@ var should  = require('should')
 
 describe('nanomsg.bufferopt', function() {
 
-  it('should support asBuffer option', function (done){
+  it('should support string encoding', function (done){
 
-    var req   = nano.socket('req',{
-      //the default, so we dont have to set it to true
-      asBuffer:true
-    })
-
-    var rep   = nano.socket('rep',{
-      asBuffer:false
-    })
-
+    var req   = nano.socket('req')
+    var rep   = nano.socket('rep')
     var addr  = 'tcp://127.0.0.1:44443'
+
+    rep.setEncoding('utf8')
 
     req.connect(addr)
     rep.bind(addr)
 
-    req.on('msg', function (msg){
+    req.on('data', function (msg){
 
       msg.should.be.an.instanceOf(Buffer)
 
@@ -28,16 +23,16 @@ describe('nanomsg.bufferopt', function() {
       done()
     })
 
-    rep.on('msg', function (msg){
+    rep.on('data', function (msg){
 
       msg.should.be.an.instanceOf(String)
 
       msg.should.equal('foo')
 
-      rep.send('bar')
+      rep.write('bar')
     })
 
-    req.send('foo')
+    req.write('foo')
 
   })
 

--- a/test/nanomsg.connect.js
+++ b/test/nanomsg.connect.js
@@ -12,9 +12,11 @@ describe('nanomsg.connect', function() {
   var push2 = nano.socket('push')
   var push3 = nano.socket('push')
 
+  //connect pull to all three push sockets
   pull.connect(addr)
   pull.connect(addr2)
   pull.connect(addr3)
+
   push.bind(addr)
   push2.bind(addr2)
   push3.bind(addr3)
@@ -36,7 +38,7 @@ describe('nanomsg.connect', function() {
 
     var msgs = 0
 
-    pull.on('msg', function(msg){
+    pull.on('data', function(msg){
 
       msg = String(msg)
 
@@ -62,9 +64,9 @@ describe('nanomsg.connect', function() {
     })
 
     setImmediate(function(){
-      push.send('hello from one source')
-      push2.send('hello from another source')
-      push3.send('hello from yet another source')
+      push.write('hello from one source')
+      push2.write('hello from another source')
+      push3.write('hello from yet another source')
     })
 
   })

--- a/test/nanomsg.recv.js
+++ b/test/nanomsg.recv.js
@@ -11,20 +11,19 @@ describe('nanomsg.recv', function() {
   pub.bind(addr)
   sub.connect(addr)
 
-  it('should have a send method', function(done){
+  it('should have a write method', function (done) {
 
     pub.should.be.an.instanceOf(Object)
-      .with.a.property('send')
+      .with.a.property('write')
       .which.is.a.Function
 
     done()
   })
 
-  it('should have a recv method', function(done){
+  it('should have a readable property', function (done) {
 
     sub.should.be.an.instanceOf(Object)
-      .with.a.property('recv')
-      .which.is.a.Function
+      .with.a.property('readable')
 
     done()
   })
@@ -33,7 +32,7 @@ describe('nanomsg.recv', function() {
 
     var msgs = 0
 
-    sub.on('msg',function(msg){
+    sub.on('data',function (msg) {
 
       msgs++
 
@@ -52,9 +51,9 @@ describe('nanomsg.recv', function() {
 
     })
 
-    pub.send('hello from nanømsg!')
-    pub.send('foo bar')
-    pub.send('barnacle')
+    pub.write('hello from nanømsg!')
+    pub.write('foo bar')
+    pub.write('barnacle')
 
   })
 

--- a/test/nanomsg.sendperf.js
+++ b/test/nanomsg.sendperf.js
@@ -5,29 +5,25 @@ var semver  = require('semver')
 describe('nanomsg.sendperf', function() {
 
   var pub    = nano.socket('pub')
-  var sub    = nano.socket('sub',{
-    asBuffer:true,
-    stopBufferOverflow: true
-  })
-  var recv    = 0
-  var addr    = 'inproc://whatever'
+  var sub    = nano.socket('sub',{ stopBufferOverflow: true })
+  var recv    = 0, addr    = 'inproc://whatever'
 
   sub.connect(addr)
 
-  it('should send a million messages', function(done){
+  it('should send a hundred thousand messages', function (done) {
 
     pub.bind(addr)
 
-    sub.on('msg',function(msg){
+    sub.on('data',function(msg){
 
-      if(recv > 999999){
+      if(recv > 99999){
         sub.close(); pub.close();
-        recv.should.equal(1000000)
+        recv.should.equal(100000)
         done()
       }
     })
 
-    do pub.send('count it')
-    while(++recv < 1000000)
+    do pub.write('count it')
+    while(++recv < 100000)
   })
 })

--- a/test/nanomsg.shutdown.js
+++ b/test/nanomsg.shutdown.js
@@ -12,7 +12,7 @@ describe('nanomsg.shutdown', function() {
     p4      : nano.socket('pub'),
     p5      : nano.socket('pub')
   }
-  var sub   = nano.socket('sub',{asBuffer:false})
+  var sub   = nano.socket('sub')
 
   it('should bind and connect multiple',function(done){
     pubs.p1.bind(addr+1)
@@ -50,16 +50,16 @@ describe('nanomsg.shutdown', function() {
 
     Object.keys(sub.how).length.should.equal(5)
 
-    sub.on('msg', function(msg){
+    sub.on('data', function (msg) {
 
-      if(msg == 'hello from p1'){
-        if(i++ == 10) console.log(sub.shutdown('tcp://127.0.0.1:44451'))
+      if (String(msg) == 'hello from p1') {
+        if (i++ == 10) console.log(sub.shutdown('tcp://127.0.0.1:44451'))
 
         //lets crash this test if we keep getting messages after shutdown
-        if(i > 11) throw 'it'
+        if (i > 11) throw 'it'
 
         //one more msg after calling shutdown is acceptable
-        if(i == 11){
+        if (i == 11) {
           for(var h in sub.how) actives.push(h)
           actives.length.should.equal(4)
           if(actives.length < 5){
@@ -77,11 +77,11 @@ describe('nanomsg.shutdown', function() {
     })
 
     var pubInterval = setInterval(function(){
-      pubs.p1.send('hello from p1')
-      pubs.p2.send('hello from p2')
-      pubs.p3.send('hello from p3')
-      pubs.p4.send('hello from p4')
-      pubs.p5.send('hello from p5')
+      pubs.p1.write('hello from p1')
+      pubs.p2.write('hello from p2')
+      pubs.p3.write('hello from p3')
+      pubs.p4.write('hello from p4')
+      pubs.p5.write('hello from p5')
     },5)
   })
 


### PR DESCRIPTION
- new streams interface for all send and receive operations
- complete API change

just to be clear: this change wholesale removes and replaces `EventEmitter`. Instead socket inherits characterisitcs from module [`duplexify`](https://github.com/mafintosh/duplexify/blob/master/index.js) via its exported class/prototype/constructor/instance whatever you call it

Just from what I saw testing this change on my machine this morning, it's clear that streams are way slower than a plain `EventEmitter`. However, it's only noticable when you're dealing with upwards of hundreds of thousands or millions of messages. i can bet that send larger message envelopes (higher throughput) the performance degradation is less substantial 

resolves https://github.com/reqshark/nanomsg.iojs/issues/3
